### PR TITLE
Feat grid common layout

### DIFF
--- a/components/grid.css
+++ b/components/grid.css
@@ -1,0 +1,55 @@
+.grid {
+  display: grid;
+}
+
+/* mobile first approach */
+
+.grid-20-80,
+.grid-auto-1fr-auto,
+.grid-50-50,
+.grid-three-column {
+  grid-template-columns: 1fr;
+}
+
+.grid-y-center {
+  align-items: center;
+}
+
+.grid-x-center {
+  justify-content: center;
+}
+
+/* center item both vertically and horizontally */
+.grid-center {
+  place-items: center;
+}
+
+.gap-1 {
+  gap: 1rem;
+}
+
+.gap-x-1 {
+  column-gap: 1rem;
+}
+
+.gap-y-1 {
+  row-gap: 1rem;
+}
+
+@media screen and (min-width: 769px) {
+  .grid-20-80 {
+    grid-template-columns: 20% 1fr;
+  }
+
+  .grid-auto-1fr-auto {
+    grid-template-columns: auto 1fr auto;
+  }
+
+  .grid-50-50 {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .grid-three-column {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,1 +1,2 @@
 @import url(./components/spacing.css);
+@import url(./components/grid.css);


### PR DESCRIPTION
I have added common grid layout patterns that users can use quickly to make a responsive layout. 

Layout consists of 
- 20-80% layout (two unequal columns)
- auto-1fr-auto ( three columns with first and last column having a width equal to the max-content)
- grid-50-50 ( two equal columns)
- grid-three-column ( three equal columns

![grid example](https://user-images.githubusercontent.com/76593140/151713428-fd28905c-7302-4caa-85b2-9506ce4cd7c0.gif)
